### PR TITLE
Add jasmine-promise-matchers module

### DIFF
--- a/lib/configs/karma.conf.js
+++ b/lib/configs/karma.conf.js
@@ -68,6 +68,7 @@ module.exports = function(karmaConfig) {
         files: [
             '../shims/bind.js',
             '../../node_modules/jasmine-expect/dist/jasmine-matchers.js',
+            '../../node_modules/jasmine-promise-matchers/dist/jasmine-promise-matchers.js',
             entry
         ],
         mochaReporter: {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "isparta-loader": "^1.0.0",
     "jasmine-core": "^2.2.0",
     "jasmine-expect": "^2.0.0-beta1",
+    "jasmine-promise-matchers": "^2.0.2",
     "jjv-utils": "^1.0.1",
     "js-yaml": "^3.4.2",
     "json-loader": "^0.5.2",


### PR DESCRIPTION
See https://github.com/bvaughn/jasmine-promise-matchers.

It allows to write

``` js
var promise = api.get('/data');
expect(promise).toBeResolvedWith('some data');
```

instead of 

``` js
handler = {
    success: function(data) {
        result = data;
    },
    error: function(err) {
        errorStatus = err.status;
    }
};
//
api.get('/data')
    .then(handler.success, handler.error);

expect(handler.success).toHaveBeenCalled();
expect(result).toEqual('some data');
expect(handler.error).not.toHaveBeenCalled();
expect(errorStatus).toEqual('');
```
